### PR TITLE
Fix error when viewing other languages

### DIFF
--- a/poc.py
+++ b/poc.py
@@ -70,7 +70,7 @@ def execute_cmd(addr, cmd, package):
             with open(package + ".apk", 'wb') as f:
                 f.write(resp.content)
         else:
-            print(text)
+            print(text.encode('utf-8'))
 
 
 def is_up(addr):


### PR DESCRIPTION
Fix `UnicodeEncodeError: 'ascii' codec can't encode characters in position 48-53: ordinal not in range(128)`